### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/timilehinozolua124/867ee70e-8290-43ca-bf80-1e245497db5f/d35f8db2-bb4f-484c-b77f-69c1a7fc8260/_apis/work/boardbadge/41f36869-baf9-403c-8a55-22017e946462)](https://dev.azure.com/timilehinozolua124/867ee70e-8290-43ca-bf80-1e245497db5f/_boards/board/t/d35f8db2-bb4f-484c-b77f-69c1a7fc8260/Microsoft.RequirementCategory)
 # timi


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/timilehinozolua124/867ee70e-8290-43ca-bf80-1e245497db5f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.